### PR TITLE
Herokuにデプロイできない問題の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,10 @@ group :development do
   gem 'web-console', '>= 3.3.0'
 end
 
+group :production do
+  gem 'pg'
+end
+
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     execjs (2.7.0)
     faker (2.11.0)
       i18n (>= 1.6, < 2)
+    ffi (1.12.2)
     ffi (1.12.2-x64-mingw32)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -131,10 +132,14 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    msgpack (1.3.3)
     msgpack (1.3.3-x64-mingw32)
+    mysql2 (0.5.3)
     mysql2 (0.5.3-x64-mingw32)
     nenv (0.3.0)
     nio4r (2.5.2)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
     nokogiri (1.10.9-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.3)
@@ -191,6 +196,8 @@ GEM
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.2.1)
+      ffi (~> 1.9)
     sassc (2.2.1-x64-mingw32)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -242,6 +249,7 @@ GEM
     zeitwerk (2.3.0)
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES

--- a/config/database.yml
+++ b/config/database.yml
@@ -48,7 +48,10 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
-  <<: *default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
   database: sample_app1_production
   username: sample_app1
   password: <%= ENV['SAMPLE_APP1_DATABASE_PASSWORD'] %>
+  


### PR DESCRIPTION
# 実装の概要
- production環境(本番環境)におけるgem 'pg'の追加
- production環境でpostgresqlを使用できるよう設定変更

## production環境(本番環境)におけるgem 'pg'の追加
Herokuでデフォルトで使用されるデータベースがPostgresqlと言うもののため追加。
gem 'pg'はpostgresqlと連携するために必要なgem。

Herokuにデプロイした場合、Railsは自動でproduction環境と認識するため、production環境でのみインストールするよう自動設定。

なお、デプロイした際に、自動でbundle installされるため気にする必要はない

## production環境でpostgresqlを使用できるよう設定変更
postgresqlを使用するように変更